### PR TITLE
feat(vorm-nuxt): add validator auto-imports and peer dependency support

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -13,7 +13,10 @@
   "ignore": [
     "docs",
     "playground"
-  ]
+  ],
+  "___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH": {
+    "onlyUpdatePeerDependentsWhenOutOfRange": true
+  }
 }
 
 

--- a/packages/vorm-nuxt/package.json
+++ b/packages/vorm-nuxt/package.json
@@ -37,6 +37,9 @@
     "@nuxt/kit": "^4.1.2",
     "vorm-vue": "workspace:^"
   },
+  "peerDependencies": {
+    "vorm-vue": "workspace:^"
+  },
   "devDependencies": {
     "vorm-vue": "workspace:*",
     "@antfu/eslint-config": "^5.4.1",

--- a/packages/vorm-nuxt/src/module.ts
+++ b/packages/vorm-nuxt/src/module.ts
@@ -3,6 +3,7 @@ import { addComponent, addImports, addPlugin, createResolver, defineNuxtModule }
 
 export interface ModuleOptions {
   autoImports?: boolean
+  autoImportValidators?: boolean
   components?: boolean
 }
 
@@ -17,6 +18,7 @@ const module: NuxtModule<ModuleOptions> = defineNuxtModule<ModuleOptions>({
 
   defaults: {
     autoImports: true,
+    autoImportValidators: false,
     components: true
   },
 
@@ -33,6 +35,18 @@ const module: NuxtModule<ModuleOptions> = defineNuxtModule<ModuleOptions>({
         { name: 'useVormContext', from: 'vorm-vue' },
         // Types
         { name: 'VormSchema', from: 'vorm-vue', type: true }
+      ])
+    }
+
+    if (options.autoImportValidators) {
+      addImports([
+        { name: 'minLength', from: 'vorm-vue' },
+        { name: 'maxLength', from: 'vorm-vue' },
+        { name: 'min', from: 'vorm-vue' },
+        { name: 'max', from: 'vorm-vue' },
+        { name: 'between', from: 'vorm-vue' },
+        { name: 'step', from: 'vorm-vue' },
+        { name: 'matchField', from: 'vorm-vue' }
       ])
     }
 


### PR DESCRIPTION
- Add vorm-vue as peerDependency to enable direct imports
- Add autoImportValidators option (default: false) for optional auto-imports
- Auto-import all 7 validators: minLength, maxLength, min, max, between, step, matchField
- Add experimental changeset option to prevent unnecessary version bumps