### PR TITLE
fix(vorm-vue): isValid now requires all fields to be validated

### DIFF
--- a/.changeset/fix-isvalid-requires-all-fields.md
+++ b/.changeset/fix-isvalid-requires-all-fields.md
@@ -1,0 +1,7 @@
+---
+"vorm-vue": patch
+---
+
+Fix isValid computed property to require all fields to be validated
+
+The isValid property now correctly returns false until ALL fields have been validated, not just at least one field. This fixes the issue where touching a single field would incorrectly mark the entire form as valid.

--- a/packages/vorm/src/__tests__/composables/useVorm.test.ts
+++ b/packages/vorm/src/__tests__/composables/useVorm.test.ts
@@ -58,4 +58,59 @@ describe("useVorm", () => {
     expect(vorm.dirty.email).toBe(false);
     expect(vorm.touched.email).toBe(false);
   });
+
+  describe("isValid computed property", () => {
+    it("should be false initially (no fields validated yet)", () => {
+      expect(vorm.isValid.value).toBe(false);
+    });
+
+    it("should be false when only one field is validated (not all)", async () => {
+      vorm.formData.email = "test@example.com";
+      await vorm.validateFieldByName("email");
+
+      // Only email is validated, age is not yet validated
+      expect(vorm.validatedFields.email).toBe(true);
+      expect(vorm.validatedFields.age).toBe(false);
+      expect(vorm.isValid.value).toBe(false);
+    });
+
+    it("should be true when all fields are validated and have no errors", async () => {
+      vorm.formData.email = "test@example.com";
+      vorm.formData.age = 25;
+
+      const isValid = await vorm.validate();
+
+      expect(isValid).toBe(true);
+      expect(vorm.validatedFields.email).toBe(true);
+      expect(vorm.validatedFields.age).toBe(true);
+      expect(vorm.isValid.value).toBe(true);
+    });
+
+    it("should be false when all fields are validated but at least one has an error", async () => {
+      vorm.formData.email = ""; // Empty, should trigger required error
+      vorm.formData.age = 25;
+
+      const isValid = await vorm.validate();
+
+      expect(isValid).toBe(false);
+      expect(vorm.validatedFields.email).toBe(true);
+      expect(vorm.validatedFields.age).toBe(true);
+      expect(vorm.errors.email).toBeTruthy();
+      expect(vorm.isValid.value).toBe(false);
+    });
+
+    it("should remain false after validating individual fields until all are validated", async () => {
+      // Validate first field
+      vorm.formData.email = "test@example.com";
+      await vorm.validateFieldByName("email");
+      expect(vorm.isValid.value).toBe(false);
+
+      // Validate second field
+      vorm.formData.age = 30;
+      await vorm.validateFieldByName("age");
+
+      // Now all fields are validated
+      expect(vorm.isValid.value).toBe(true);
+    });
+  });
 });

--- a/packages/vorm/src/composables/useVorm.ts
+++ b/packages/vorm/src/composables/useVorm.ts
@@ -84,11 +84,11 @@ export function useVorm(
     const validatedValues = Object.values(validatedFields);
     // Form is only valid if:
     // 1. It has fields
-    // 2. At least one field has been validated
+    // 2. All fields have been validated
     // 3. All errors are null
     return (
       errorValues.length > 0 &&
-      validatedValues.some(v => v === true) &&
+      validatedValues.every(v => v === true) &&
       errorValues.every(e => e === null)
     );
   });


### PR DESCRIPTION
Changed the isValid computed property from checking if at least one field is validated to requiring all fields to be validated before the form is considered valid. This fixes the issue where touching a single field would incorrectly mark the entire form as valid.